### PR TITLE
タグページへのパンくずリストの追加

### DIFF
--- a/app/views/admin/tags/edit.html.slim
+++ b/app/views/admin/tags/edit.html.slim
@@ -1,6 +1,8 @@
 = content_for 'content-header' do
   | タグ編集
 
+- breadcrumb :edit_admin_tag
+
 .box
   = render 'form', tag: @tag
 

--- a/app/views/admin/tags/index.html.slim
+++ b/app/views/admin/tags/index.html.slim
@@ -1,6 +1,8 @@
 = content_for 'content-header' do
   | タグ
 
+- breadcrumb :admin_tags
+
 .row
   .col-md-9
     .box.box-primary

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -91,3 +91,13 @@ crumb :edit_admin_article do |article|
   link '記事編集', edit_admin_article_path(article.uuid)
   parent :admin_articles
 end
+
+crumb :admin_tags do
+  link 'タグ', admin_tags_path
+  parent :admin_dashboard
+end
+
+crumb :edit_admin_tag do
+  link 'タグ編集'
+  parent :admin_tags
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -18,6 +18,8 @@
 
 FactoryBot.define do
   factory :tag do
-    
+    type { 'Tag' }
+    name { 'テストタグ' }
+    slug { 'test-tag' }
   end
 end

--- a/spec/system/admin_tags_spec.rb
+++ b/spec/system/admin_tags_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'AdminArticles', type: :system do
+  let(:admin) { create :user, :admin }
+  before do
+    login(admin)
+  end
+  describe 'タグ一覧画面' do
+    it 'Home > タグ というパンくずが表示されていること' do
+      visit admin_tags_path
+      within('.breadcrumb') do
+        expect(page).to have_content('Home'), '「Home」というパンくずが表示されていません'
+        expect(page).to have_content('タグ'), '「タグ」というパンくずが表示されていません'
+      end
+    end
+    it '「Home」のパンくずをクリックした時にダッシュボード画面に遷移すること' do
+      visit admin_tags_path
+      within('.breadcrumb') do
+        click_link 'Home'
+      end
+      expect(current_path).to eq(admin_dashboard_path), 'パンくずのHomeを押した時にダッシュボードに遷移していません'
+    end
+  end
+
+  describe 'タグ編集画面' do
+    let!(:tag) { create :tag }
+    it 'Home > タグ > タグ編集 というパンくずが表示されていること' do
+      visit edit_admin_tag_path(tag)
+      within('.breadcrumb') do
+        expect(page).to have_content('Home'), '「Home」というパンくずが表示されていません'
+        expect(page).to have_content('タグ'), '「タグ」というパンくずが表示されていません'
+        expect(page).to have_content('タグ編集'), '「タグ編集」というパンくずが表示されていません'
+      end
+    end
+
+    it '「タグ」のパンくずをクリックした時にタグの一覧画面に遷移すること' do
+      visit edit_admin_tag_path(tag)
+      within('.breadcrumb') do
+        click_link 'タグ'
+      end
+      expect(current_path).to eq(admin_tags_path), 'パンくずの「タグ」を押した時にタグ一覧画面に遷移していません'
+    end
+  end
+end


### PR DESCRIPTION
タグ一覧ページとタグ編集ページにパンくずリストがなかったので追加しました。