### PR TITLE
テキスト挿入時のバグ修正

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -70,7 +70,7 @@ class Article < ApplicationRecord
     article_blocks.each do |article_block|
       result << if article_block.sentence?
                   sentence = article_block.blockable
-                  sentence.body
+                  sentence.body ||= ''
                 elsif article_block.medium?
                   medium = ActiveDecorator::Decorator.instance.decorate(article_block.blockable)
                   controller.render_to_string("shared/_media_#{medium.media_type}", locals: { medium: medium }, layout: false)

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -28,6 +28,7 @@
 
 FactoryBot.define do
   factory :article do
-    
+    sequence(:title) { |n| "title-#{n}" }
+    sequence(:slug) { |n| "slug-#{n}" }
   end
 end

--- a/spec/system/admin_articles_previews_spec.rb
+++ b/spec/system/admin_articles_previews_spec.rb
@@ -2,10 +2,12 @@ require 'rails_helper'
 
 RSpec.describe 'AdminArticlesPreview', type: :system do
   let(:admin) { create :user, :admin }
+  before do
+    login(admin)
+  end
   describe '記事作成画面で画像ブロックを追加' do
     context '画像を添付せずにプレビューを閲覧' do
       it '正常に表示される' do
-        login(admin)
         click_link '記事'
         visit admin_articles_path
         click_link '新規作成'
@@ -18,6 +20,21 @@ RSpec.describe 'AdminArticlesPreview', type: :system do
         switch_to_window(windows.last)
         expect(page).not_to have_content("Nil location provided. Can't build URI"), 'エラーページが表示されています'
         expect(page).to have_content('テスト記事'), 'プレビューページが正しく表示されていません'
+      end
+    end
+  end
+
+  describe '記事作成画面でテキストブロックを追加' do
+    let!(:article) { create :article }
+    context 'テキストを入力せずにプレビューを閲覧' do
+      it '記事プレビュー画面に遷移できることを確認' do
+        visit edit_admin_article_path(article.uuid)
+        click_link 'ブロックを追加する'
+        click_link '文章'
+        click_link 'プレビュー'
+        switch_to_window(windows.last)
+        expect(page).to have_content(article.title), 'プレビューページが正しく表示されていません'
+        expect(page).not_to have_content('no implicit conversion of nil into String'), 'プレビューページがエラー画面になっています'
       end
     end
   end


### PR DESCRIPTION
テキストブロックを追加し、テキストを入力しない状態でプレビュー画面に遷移した際のエラーを解消しました。

- articleモデルにnilガードを追加