### PR TITLE
公開待ちステータスの追加

### DIFF
--- a/app/controllers/admin/articles/publishes_controller.rb
+++ b/app/controllers/admin/articles/publishes_controller.rb
@@ -5,7 +5,7 @@ class Admin::Articles::PublishesController < ApplicationController
 
   def update
     @article.published_at = Time.current unless @article.published_at?
-    @article.state = :published
+    @article.state = @article.publishable? ? :published : :publish_wait
 
     if @article.valid?
       Article.transaction do
@@ -13,8 +13,7 @@ class Admin::Articles::PublishesController < ApplicationController
         @article.save!
       end
 
-      flash[:notice] = '記事を公開しました'
-
+      flash[:notice] = @article.message_on_published
       redirect_to edit_admin_article_path(@article.uuid)
     else
       flash.now[:alert] = 'エラーがあります。確認してください。'

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -34,12 +34,14 @@ class Admin::ArticlesController < ApplicationController
   def update
     authorize(@article)
 
-    if @article.update(article_params)
-      flash[:notice] = '更新しました'
-      redirect_to edit_admin_article_path(@article.uuid)
-    else
-      render :edit
-    end
+    @article.assign_attributes(article_params)
+    @article.adjust_state
+      if @article.save
+        flash[:notice] = '更新しました'
+        redirect_to edit_admin_article_path(@article.uuid)
+      else
+        render :edit
+      end
   end
 
   def destroy

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -39,7 +39,7 @@ class Article < ApplicationRecord
 
   has_one_attached :eye_catch
 
-  enum state: { draft: 0, published: 1 }
+  enum state: { draft: 0, published: 1, publish_wait: 2 }
 
   validates :slug, slug_format: true, uniqueness: true, length: { maximum: 255 }, allow_blank: true
   validates :title, presence: true, uniqueness: true, length: { maximum: 255 }
@@ -63,6 +63,7 @@ class Article < ApplicationRecord
   scope :new_arrivals, -> { viewable.order(published_at: :desc) }
   scope :by_category, ->(category_id) { where(category_id: category_id) }
   scope :title_contain, ->(word) { where('title LIKE ?', "%#{word}%") }
+  scope :past_published, -> { where('published_at <= ?', Time.current) }
 
   def build_body(controller)
     result = ''
@@ -89,5 +90,27 @@ class Article < ApplicationRecord
 
   def prev_article
     @prev_article ||= Article.viewable.order(published_at: :desc).find_by('published_at < ?', published_at)
+  end
+
+  def publishable?
+    Time.current >= published_at
+  end
+
+  def message_on_published
+    if published?
+      '公開しました'
+    elsif publish_wait?
+      '公開待ちにしました'
+    end
+  end
+
+  def adjust_state
+    return if draft?
+
+    self.state = if publishable?
+                   :published
+                  else
+                   :publish_wait
+                  end
   end
 end

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -14,6 +14,7 @@ ja:
       state:
         draft: '下書き'
         published: '公開'
+        publish_wait: '公開待ち'
     medium:
       media_type:
         image: '画像'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,3 +18,17 @@
 # end
 
 # Learn more: http://github.com/javan/whenever
+
+require File.expand_path(File.dirname(__FILE__) + "/environment")
+
+rails_env = ENV['RAILS_ENV'] || :development
+
+set :environment, rails_env
+
+set :output, "#{Rails.root}/log/cron.log"
+
+job_type :rake, "source /User/inoserisa/.zshrc; export PATH=\"$HOME/.rbenv/bin:$PATH\"; eval \"$(rbenv init -)\"; cd :path && RAILS_ENV=:environment bundle exec rake :task :output"
+
+every :hour do
+  rake 'article_state:change_to_be_published'
+end

--- a/lib/tasks/article_state.rake
+++ b/lib/tasks/article_state.rake
@@ -1,0 +1,6 @@
+namespace :article_state do
+  desc '公開待ちの中で、公開日時が過去になっているものがあれば、ステータスを「公開」に変更されるようにする'
+  task change_to_be_published: :environment do
+    Article.publish_wait.past_published.find_each(&:published!)
+  end
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -30,5 +30,20 @@ FactoryBot.define do
   factory :article do
     sequence(:title) { |n| "title-#{n}" }
     sequence(:slug) { |n| "slug-#{n}" }
+    category
+  end
+
+  trait :draft do
+    state { :draft }
+  end
+
+  trait :future do
+    published_at { DateTime.now.since(1.hours) }
+    state { :publish_wait }
+  end
+
+  trait :past do
+    published_at { DateTime.now.ago(1.hours) }
+    state { :published }
   end
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -18,6 +18,8 @@
 
 FactoryBot.define do
   factory :category do
-    
+    type { 'Category' }
+    sequence(:name) { |n| "応用課題#{n}" }
+    sequence(:slug) { |n| "ouyou-kadai#{n}" }
   end
 end

--- a/spec/lib/tasks/update_article_state_spec.rb
+++ b/spec/lib/tasks/update_article_state_spec.rb
@@ -1,0 +1,15 @@
+require 'rake_helper'
+
+describe 'article_state:update_article_state' do
+  subject(:task) { Rake.application['article_state:update_article_state'] }
+  before do
+    create(:article, state: :publish_wait, published_at: Time.current - 1.day)
+    create(:article, state: :publish_wait, published_at: Time.current + 1.day)
+    create(:article, state: :draft)
+  end
+  # メソッド名やスコープ名の制約があるため自動コードレビューでは実施していません。
+  # 参考までに解答例を書いておきます。
+  xit 'update_article_state' do
+    expect { task.invoke }.to change { Article.published.size }.from(0).to(1)
+  end
+end

--- a/spec/rake_helper.rb
+++ b/spec/rake_helper.rb
@@ -1,0 +1,12 @@
+# 参考 https://qiita.com/aeroastro/items/c97bd26ce8b8818b6bed
+require 'rails_helper'
+require 'rake'
+RSpec.configure do |config|
+  config.before(:suite) do
+    Rails.application.load_tasks # Load all the tasks just as Rails does (`load 'Rakefile'` is another simple way)
+  end
+
+  config.before(:each) do
+    Rake.application.tasks.each(&:reenable) # Remove persistency between examples
+  end
+end

--- a/spec/system/admin_articles_spec.rb
+++ b/spec/system/admin_articles_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'AdminArticles', type: :system do
+  let(:admin) { create :user, :admin }
+  let(:draft_article) { create :article, :draft }
+  let(:future_article) { create :article, :future }
+  let(:past_article) { create :article, :past }
+  before do
+    login(admin)
+  end
+  describe '記事編集画面' do
+    context '公開日時を未来の日付に設定し「公開する」を押す' do
+      it 'ステータスを「公開待ち」に変更して「記事を公開待ちにしました」とフラッシュメッセージが表示されること' do
+        visit edit_admin_article_path(future_article.uuid)
+        click_on '公開する'
+        expect(page).to have_content('公開待ちにしました'), '「公開待ちにしました」というメッセージが表示されていません'
+        expect(page).to have_select('状態', selected: '公開待ち'), 'ステータスが「公開待ち」になっていません'
+      end
+    end
+
+    context '公開日時を過去の日付に設定し「公開する」を押す' do
+      it 'ステータスを「公開」に変更して「記事を公開しました」とフラッシュメッセージが表示されること' do
+        visit edit_admin_article_path(past_article.uuid)
+        click_on '公開する'
+        expect(page).to have_content('公開しました'), '「公開しました」というメッセージが表示されていません'
+        expect(page).to have_select('状態', selected: '公開'), '「ステータスが「公開」になっていません'
+      end
+    end
+
+    context 'ステータスが下書き以外の状態で公開日時を未来の日付に設定し「更新する」を押す' do
+      it 'ステータスを「公開待ち」に変更して「更新しました」とフラッシュメッセージが表示されること' do
+        visit edit_admin_article_path(future_article.uuid)
+        click_on '更新する'
+        expect(page).to have_content('更新しました'), '「更新しました」というメッセージが表示されていません'
+        expect(page).to have_select('状態', selected: '公開待ち'), '「ステータスが「公開待ち」になっていません'
+      end
+    end
+
+    context 'ステータスが下書き以外の状態で公開日時を過去の日付に設定し「更新する」を押す' do
+      it 'ステータスを「公開」に変更して「更新しました」とフラッシュメッセージが表示されること' do
+        visit edit_admin_article_path(past_article.uuid)
+        click_on '更新する'
+        expect(page).to have_content('更新しました'), '「更新しました」というメッセージが表示されていません'
+        expect(page).to have_select('状態', selected: '公開'), 'ステータスが「公開」になっていません'
+      end
+    end
+
+    context 'ステータスが下書き状態で「更新する」を押す' do
+      it 'ステータスは「下書き」のまま「更新しました」とフラッシュメッセージが表示されること' do
+        visit edit_admin_article_path(draft_article.uuid)
+        click_on '更新する'
+        expect(page).to have_content('更新しました'), '「更新しました」というメッセージが表示されていません'
+        expect(page).to have_selector(:css, '.form-control', text: '下書き'), 'ステータスが「下書き」になっていません'
+      end
+    end
+  end
+end


### PR DESCRIPTION
ブログのステータスに公開待ちを追加しました。

- 未来の日付で公開した場合自動的に公開待ちに。

- Rakeタスク、wheneverを導入し、1時間ごとにスケジュールを確認し時間がきたものは公開ステータスに変更されるようにしました。