### PR TITLE
埋め込みメディアタイプにTwitterを追加

### DIFF
--- a/app/decorators/article_block_decorator.rb
+++ b/app/decorators/article_block_decorator.rb
@@ -5,7 +5,7 @@ module ArticleBlockDecorator
     elsif medium?
       '<i class="fa fa-image"></i>'.html_safe
     elsif embed?
-      '<i class="fa fa-youtube-play"></i>'.html_safe
+      blockable.youtube? ? '<i class="fa fa-youtube-play"></i>'.html_safe : '<i class="fa fa-twitter"></i>'.html_safe
     end
   end
 

--- a/app/models/embed.rb
+++ b/app/models/embed.rb
@@ -13,7 +13,11 @@ class Embed < ApplicationRecord
   has_one :article_block, as: :blockable, dependent: :destroy
   has_one :article, through: :article_block
 
-  enum embed_type: { youtube: 0 }
+  enum embed_type: { youtube: 0, twitter: 1 }
 
   validates :identifier, length: { maximum: 200 }
+
+  def split_id_from_youtube_url
+    identifier.split('/').last if youtube?
+  end
 end

--- a/app/views/admin/articles/article_blocks/_insert_block.html.slim
+++ b/app/views/admin/articles/article_blocks/_insert_block.html.slim
@@ -42,7 +42,9 @@
             method: :post, \
             params: { article_block: { level: level, blockable_type: 'embed' } } \
             } do
-          i.fa.fa-youtube-play
+          .d-inline-flex
+            i.fa.fa-youtube-play
+            i.fa.fa-twitter
           '
           | 埋め込み
 

--- a/app/views/admin/articles/article_blocks/_show_embed.html.slim
+++ b/app/views/admin/articles/article_blocks/_show_embed.html.slim
@@ -2,6 +2,9 @@
   - if embed.youtube?
     - if embed.identifier?
       = render 'shared/embed_youtube', embed: embed, width: 560, height: 315
+  - elsif embed.twitter?
+    - if embed.identifier?
+      = render 'shared/embed_twitter', embed: embed, width: 560, height: 315
 
 .box-footer
   .pull-right

--- a/app/views/shared/_embed_twitter.html.slim
+++ b/app/views/shared/_embed_twitter.html.slim
@@ -1,0 +1,9 @@
+ruby:
+  embed = local_assigns[:embed]
+  width = local_assigns[:width] || 853
+  height = local_assigns[:height] || 480
+  
+.embed-twitter
+  blockquote.twitter-tweet 
+    a href="#{embed.identifier}"
+  script async="" charset='utf-8' src="https://platform.twitter.com/widgets.js"

--- a/app/views/shared/_embed_youtube.html.slim
+++ b/app/views/shared/_embed_youtube.html.slim
@@ -4,5 +4,5 @@ ruby:
   height = local_assigns[:height] || 480
 
 .embed-youtube
-  = content_tag 'iframe', nil, width: width, height: height, src: "https://www.youtube.com/embed/#{embed.identifier}", \
+  = content_tag 'iframe', nil, width: width, height: height, src: "https://www.youtube.com/embed/#{embed.split_id_from_youtube_url}", \
     frameborder: 0, gesture: 'media', allow: 'encrypted-media', allowfullscreen: true

--- a/spec/system/admin_articles_embedded_media_spec.rb
+++ b/spec/system/admin_articles_embedded_media_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'AdminArticlesEmbeddedMedia', type: :system do
+  let(:admin) {create(:user, :admin)}
+  let(:article) {create :article}
+
+  describe '記事の埋め込みブロックを追加' do
+    before do
+      login(admin)
+      article
+      visit edit_admin_article_path(article.uuid)
+      click_on('ブロックを追加する')
+      click_on('埋め込み')
+      click_on('編集')
+    end
+
+    context 'YouTubeを選択しアップロード' do
+      it 'プレビューした記事にYouTubeが埋め込まれていること', js: true do
+        select 'YouTube', from: 'embed[embed_type]'
+        fill_in 'ID', with: 'https://youtu.be/dZ2dcC4OnQE'
+        page.all('.box-footer')[0].click_button('更新する')
+        click_on('プレビュー')
+        switch_to_window(windows.last)
+        expect(current_path).to eq(admin_article_preview_path(article.uuid)), '更新した記事を正しくプレビューできていません'
+        expect(page).to have_selector("iframe[src='https://www.youtube.com/embed/dZ2dcC4OnQE']"), 'プレビューした記事にYouTubeのコンテンツが埋め込まれません'
+      end
+    end
+
+    # TwitterからXへの変更に伴いコメントアウト
+    # context 'Twitterを選択しアップロード' do
+    #   it 'プレビューした記事にTwitterが埋め込まれていること', js: true do
+    #     select 'Twitter', from: 'embed[embed_type]'
+    #     fill_in 'ID', with: 'https://twitter.com/_RUNTEQ_/status/1219795644807667712'
+    #     page.all('.box-footer')[0].click_button('更新する')
+    #     sleep 1 # Json parce処理でUPDATE完了前にプレビューしないよう待機
+    #     click_on('プレビュー')
+    #     switch_to_window(windows.last)
+    #     expect(current_path).to eq(admin_article_preview_path(article.uuid)), '更新した記事を正しくプレビューできていません'
+    #     # embedded_urlだと検証しづらいので固定値で確認
+    #     # expect(page).to have_selector("iframe[src='#{embedded_url_twitter}']")
+    #     sleep 2 # 全体テスト実行時に画面遷移が追いつかないので待機
+    #     expect(page).to have_selector(".twitter-tweet"), 'プレビューした記事にTwitterのコンテンツが埋め込まれません'
+    #   end
+    # end
+  end
+end


### PR DESCRIPTION
記事への埋め込み可能メディアタイプにX(旧Twitter)を追加しました。

- ブロックのアイコンも埋め込みタイプに合わせて変更されるようにしました

- Twitter APIを使わずに、Twitter埋め込み用ウィジェットのJavaScriptを読み込んでいます